### PR TITLE
prometheus_client 0.13.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.12.0" %}
+{% set version = "0.13.1" %}
 
 package:
   name: prometheus_client
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/prometheus/client_python/archive/v{{ version }}.tar.gz
-  sha256: e334d2a4e5287ead716a8ad88ac612c99d7bdf7a28edca11c7e750dcd3d50307
+  sha256: 52d68963764f94f9c6a131d17c7c74b82d45f871c809f7bbbc385cb3602ca180
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
+{% set name = "prometheus_client" %}
 {% set version = "0.13.1" %}
 
 package:
-  name: prometheus_client
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:


### PR DESCRIPTION
Update prometheus_client to 0.13.1

Bug Tracker: new open issues https://github.com/prometheus/client_python/issues
Github releases:  drop support for Python versions 2.7, 3.4, and 3.5 https://github.com/prometheus/client_python/releases
License: https://github.com/prometheus/client_python/blob/v0.13.1/LICENSE
Upstream setup file: https://github.com/prometheus/client_python/blob/v0.13.1/setup.py

The package prometheus_client is mentioned inside the packages:
flower | jupyter_server | jupyterhub | luigi | notebook | ray-packages |

Actions:
1. Use jinja2 templates

Result:
- all-succeeded