### PR TITLE
Update to 0.14.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python   
+    - python
 
 test:
   imports:
@@ -41,7 +41,7 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  summary: Python client for the Prometheus monitoring system 
+  summary: Python client for the Prometheus monitoring system
   dev_url: https://github.com/prometheus/client_python
   doc_url: https://github.com/prometheus/client_python#readme
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "prometheus_client" %}
-{% set version = "0.13.1" %}
+{% set version = "0.14.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,11 @@ package:
 
 source:
   url: https://github.com/prometheus/client_python/archive/v{{ version }}.tar.gz
-  sha256: 52d68963764f94f9c6a131d17c7c74b82d45f871c809f7bbbc385cb3602ca180
+  sha256: db2b212c690fb1dbd0da807753af9247da28610c1d93fa12fa0b43bd30d22964
 
 build:
   number: 0
   skip: True  # [py<36]
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -22,7 +21,7 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python >=3.6
+    - python   
 
 test:
   imports:
@@ -34,7 +33,7 @@ test:
     - pip check
   requires:
     - pip
-    - python <3.10
+    - python
     - twisted
 
 about:


### PR DESCRIPTION
Version bump for `prometheus_client` from `0.1.3.1`  to `0.14.1.`

- Removed pinnings
- Removed `noarch:python`
- Updated sha256