### PR TITLE
prometheus_client 0.21.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,14 @@ requirements:
   run:
     - python
 
+{% set ignore_tests = "" %}
+# >   os.unlink(fullname)
+# E   PermissionError: [WinError 32] The process cannot access the file because it is being used by another process
+{% set ignore_tests = " --ignore=tests/test_multiprocess.py" %}  # [win]
+# E   TypeError: expected str, bytes or os.PathLike object, not NoneType
+{% set ignore_tests = ignore_tests + " --ignore=tests/test_twisted.py" %}  # [win]
+{% set ignore_tests = ignore_tests + " --ignore=tests/test_wsgi.py" %}  # [win]
+
 test:
   source_files:
     - tests
@@ -33,7 +41,7 @@ test:
     - prometheus_client.twisted
   commands:
     - pip check
-    - pytest -v tests
+    - pytest -v {{ ignore_tests }} tests
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "prometheus_client" %}
-{% set version = "0.21.0" %}
+{% set version = "0.21.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/prometheus_client-{{ version }}.tar.gz
-  sha256: 96c83c606b71ff2b0a433c98889d275f51ffec6c5e267de37c7a2b5c9aa9233e
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb
 
 build:
   number: 0
-  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<38]
 
 requirements:
   host:
@@ -24,6 +24,8 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - prometheus_client
     - prometheus_client.bridge
@@ -31,19 +33,21 @@ test:
     - prometheus_client.twisted
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
-    - python
+    - pytest
     - twisted
 
 about:
   home: https://github.com/prometheus/client_python
+  summary: Python client for the Prometheus monitoring system.
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  summary: Python client for the Prometheus monitoring system
   dev_url: https://github.com/prometheus/client_python
   doc_url: https://github.com/prometheus/client_python#readme
+  description: The official Python client for Prometheus.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
prometheus_client 0.21.1 

**Destination channel:** Defaults

### Links

- [PKG-7799]
- dev_url:        https://github.com/prometheus/client_python/tree/v0.21.1
- conda_forge:    https://github.com/conda-forge/prometheus_client-feedstock
- pypi:           https://pypi.org/project/prometheus_client/0.21.1
- pypi inspector: https://inspector.pypi.io/project/prometheus_client/0.21.1

### Explanation of changes:

- new version number


[PKG-7799]: https://anaconda.atlassian.net/browse/PKG-7799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ